### PR TITLE
Update rightswype.js

### DIFF
--- a/rightswype.js
+++ b/rightswype.js
@@ -1,6 +1,7 @@
-// Basically, what it does is, selects the right swipe button class name, and keeps clicking
+// Step 1: Copy and paste this line into the Console and hit Enter
+// tldr; using jquery, we're selecting the like button
+var swype  = $("[aria-label='Like']");
 
-func = setInterval(function() {
- var swype  = document.getElementsByClassName("recsGamepad__button--like")
-  swype[0].click()
-}, 1000)
+// Step 2: Copy and paste this line into the Console and hit Enter
+// tldr; using click(), we click the button--750 is the time (in ms) between swipes -- feel free to adjust this
+func = setInterval(function() { swype.click() }, 750)


### PR DESCRIPTION
This works as of 3/20/19

Looks like Tinder.com changed their element naming conventions so your current code was returning an error as below:

![err](https://user-images.githubusercontent.com/16533075/54705363-0319e000-4b13-11e9-98d7-6605bdbf2d3c.PNG)

I updated the element selector, and put an arbitrary time between swipes